### PR TITLE
Document proxysql overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ calculations see exact results e.g. [here][9]).
 | Cloud us-east1 to us-east2          | 250 μs  | ?          | ?      | ?      |
 | Mutex Lock/Unlock                   | ?       | ?          | ?      | ?      |
 | {MySQL, Memcached, Redis, ..} Query | ?       | ?          | ?      | ?      |
+| ProxySQL overhead.                  | 30 μs.  |            |        |        |
 | Envoy/Nginx Overhead                | ?       | ?          | ?      | ?      |
 | {JSON, Protobuf, ..} Serializee (?) | ?       | ?          | ?      | ?      |
 | Cloud us-east to us-central         | ?       | ?          | ?      | ?      |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ calculations see exact results e.g. [here][9]).
 | Cloud us-east1 to us-east2          | 250 μs  | ?          | ?      | ?      |
 | Mutex Lock/Unlock                   | ?       | ?          | ?      | ?      |
 | {MySQL, Memcached, Redis, ..} Query | ?       | ?          | ?      | ?      |
-| ProxySQL overhead.                  | 30 μs.  |            |        |        |
+| ProxySQL overhead                   | 30 μs.  | ?          | ?      | ?      |
 | Envoy/Nginx Overhead                | ?       | ?          | ?      | ?      |
 | {JSON, Protobuf, ..} Serializee (?) | ?       | ?          | ?      | ?      |
 | Cloud us-east to us-central         | ?       | ?          | ?      | ?      |


### PR DESCRIPTION
Based on https://www.percona.com/blog/2020/08/28/proxysql-overhead-explained-and-measured/

> ProxySQL is quite efficient — 25-45 microseconds of added latency per request and hundreds of nanoseconds per row of the result set