### PR TITLE
feat: add aegis authenticated encryption algorithms throughput 

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ to improve accuracy and as hardware improves.
 | Network EU West <-> NA Central      | 100 ms      | 25 MiB/s   | 40 ms  | 40s    |
 | Network NA West <-> Singapore       | 180 ms      | 25 MiB/s   | 40 ms  | 40s    |
 | Network EU West <-> Singapore       | 160 ms      | 25 MiB/s   | 40 ms  | 40s    |
+| AEGIS-128L  (16 KiB) `[12]`         | N/A         | 100 GiB/s  | 10 μs  | 10 ms  |
+| AEGIS-128X2 (16 KiB) `[12]`         | N/A         | 200 GiB/s  | 5 μs   | 5 ms   |
+| AEGIS-128X4 (16 KiB) `[12]`         | N/A         | 280 GiB/s  | 4 μs   | 4 ms   |
+| AEGIS-256   (16 KiB) `[12]`         | N/A         | 55 GiB/s   | 20 μs  | 20 ms  |
+| AEGIS-256X2 (16 KiB) `[12]`         | N/A         | 110 GiB/s  | 10 μs  | 10 ms  |
+| AEGIS-256X4 (16 KiB) `[12]`         | N/A         | 205 GiB/s  | 5 μs   | 5 ms   |
+| AEGIS-128L  MAC (64 KiB)`[12]`      | N/A         | 110 GiB/s  | 10 μs  | 10 ms  |
+| AEGIS-128X2 MAC (64 KiB)`[12]`      | N/A         | 210 GiB/s  | 5 μs   | 5 ms   |
+| AEGIS-128X4 MAC (64 KiB)`[12]`      | N/A         | 295 GiB/s  | 3 μs   | 3 ms   |
+| AEGIS-256   MAC (64 KiB)`[12]`      | N/A         | 55 GiB/s   | 20 μs  | 20 ms  |
+| AEGIS-256X2 MAC (64 KiB)`[12]`      | N/A         | 110 GiB/s  | 10 μs  | 10 ms  |
+| AEGIS-256X4 MAC (64 KiB)`[12]`      | N/A         | 180 GiB/s  | 5 μs   | 5 ms   |
 
 [i]: https://www.cloudping.co/grid#
 
@@ -201,6 +213,7 @@ MiB/s, and 3x at ~20MiB/s, and 4x at 1MB/s.
 * `[9]`: https://github.com/protocolbuffers/protobuf/blob/d20e9a92/docs/performance.md
 * `[10]`: https://www.imperialviolet.org/2010/06/25/overclocking-ssl.html
 * `[11]`: https://github.com/inikep/lzbench
+* `[12]`: https://github.com/aegis-aead/libaegis
 * ["How to get consistent results when benchmarking on
   Linux?"](https://easyperf.net/blog/2019/08/02/Perf-measurement-environment-on-Linux#2-disable-hyper-threading).
   Great compilation of various Kernel and CPU features to toggle for reliable


### PR DESCRIPTION
### Add AEGIS encryption benchmarks from libaegis

This PR adds throughput numbers for the AEGIS family of authenticated encryption algorithms using the benchmark provided by [libaegis](https://github.com/aegis-aead/libaegis). These benchmarks were run on a GCP C3-standard-22-lssd instance which can be verified and rerun [here](https://github.com/TylerHillery/napkin-math-infra/actions/runs/14864781629).

The actual numbers have been rounded to adhere to the note provide in the README
> Some throughput and latency numbers don't line up, this is intentional for ease of calculations.

Here are the actual results
```
AEGIS-256	  60927.56 Mb/s
AEGIS-256X2	 119812.54 Mb/s
AEGIS-256X4	 220401.53 Mb/s
AEGIS-128L	 111003.49 Mb/s
AEGIS-128X2	 210681.92 Mb/s
AEGIS-128X4	 299351.57 Mb/s
AEGIS-128L MAC	 119853.45 Mb/s
AEGIS-128X2 MAC	 227321.50 Mb/s
AEGIS-128X4 MAC	 315722.91 Mb/s
AEGIS-256 MAC	  59906.16 Mb/s
AEGIS-256X2 MAC	 116962.69 Mb/s
AEGIS-256X4 MAC	 195982.35 Mb/s
```